### PR TITLE
fix missing space in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is project to demonstrate the capabilities of the CSS3 Flexbox Layout.
 
-##Prerequisites
+## Prerequisites
 
 In order to build this project you need to have Node.js and npm (Node Package Manager) installed on your system. You can download them from [here](https://nodejs.org/download/) and follow this [install instructions](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager).
 


### PR DESCRIPTION
github markdown requires to add a space after the hash character `#` so it can be correctely interpreted as a title.

[ci skip]